### PR TITLE
Entity type series

### DIFF
--- a/tests/unit/ngsi/test_entity_series.py
+++ b/tests/unit/ngsi/test_entity_series.py
@@ -30,6 +30,42 @@ def mk_entity_query_result(extra_attrs=[]):
     }
 
 
+def mk_entity_type_query_result():
+    return {
+        "entityType": "Bot",
+        "entities": [
+            {
+                "entityId": "urn:ngsi-ld:Bot:2",
+                "index": raw_tix,
+                "attributes": [
+                    {
+                        "attrName": "direction",
+                        "values": directions
+                    },
+                    {
+                        "attrName": "speed",
+                        "values": speeds
+                    }
+                ]
+            },
+            {
+                "entityId": "urn:ngsi-ld:Bot:3",
+                "index": raw_tix,
+                "attributes": [
+                    {
+                        "attrName": "direction",
+                        "values": directions
+                    },
+                    {
+                        "attrName": "speed",
+                        "values": [s + 1 for s in speeds]
+                    }
+                ]
+            },
+        ]
+    }
+
+
 def test_dynamic_model_fields():
     r = EntitySeries.from_quantumleap_format(mk_entity_query_result())
 
@@ -102,3 +138,19 @@ def test_convert_custom_entity_series_to_pandas():
 
     e_attrs_column_values = time_indexed_df['e_attr'].to_list()
     assert e_attrs_column_values == [1, 2, 3]
+
+
+def test_from_entity_type_query():
+    entity_type_query_result = mk_entity_type_query_result()
+    rs = EntitySeries.from_quantumleap_type_format(entity_type_query_result)
+    assert len(rs) == 2
+
+    bot2_series = rs['urn:ngsi-ld:Bot:2']
+    assert bot2_series.index == tix
+    assert bot2_series.direction == directions
+    assert bot2_series.speed == speeds
+
+    bot3_series = rs['urn:ngsi-ld:Bot:3']
+    assert bot3_series.index == tix
+    assert bot3_series.direction == directions
+    assert bot3_series.speed == [s + 1 for s in speeds]


### PR DESCRIPTION
This PR implements a client-side data transformation to turn Quantum Leap entity series data into a dataframe-friendly format.

For each tracked entity, Quantum Leap keeps a time-indexed sequence of changes to that entity. Each entity has a type and you can fetch all the time-indexed sequences for a given entity type from Quantum Leap with a

```
GET /v2/types/{entity_type}
```

But the returned content isn't dataframe-friendly, so this PR packs the returned data into a dictionary of `EntitySeries` values keyed by entity ID. You can then use each `EntitySeries` directly use with e.g. Pandas as in

```python
rs = ql_client.entity_type_series('Bot')
r = rs['Bot:1']  # assuming there's an entity w/ ID of 'Bot:1'
time_indexed_df = pd.DataFrame(r.dict()).set_index('index')
```

Notice the `rs` dictionary has an `EntitySeries` value for each entity series in the query result Quantum Leap returns. Each `EntitySeries` has a field called `index` containing the time index array returned by Quantum Leap. Also, it has a field for each returned attribute array and the field name is the same as the attribute name.

This implementation is meant to replace several buggy ad-hoc implementations found in kitt4sme services which caused endless deployment issues.