### PR TITLE
JSON to NGSI v2

### DIFF
--- a/fipy/__init__.py
+++ b/fipy/__init__.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Optional, Tuple
 
-__version__ = '0.6.1'
+__version__ = '0.7.0'
 
 
 def pyproject_file() -> Path:

--- a/fipy/ngsi/entity.py
+++ b/fipy/ngsi/entity.py
@@ -111,6 +111,16 @@ class BoolAttr(Attr):
     value: bool
 
 
+class ArrayAttr(Attr):
+    type = 'Array'
+    value: List
+
+
+class StructuredValueAttr(Attr):
+    type = 'StructuredValue'
+    value: Dict
+
+
 class BaseEntity(BaseModel):
     id: str
     type: str

--- a/fipy/ngsi/entity.py
+++ b/fipy/ngsi/entity.py
@@ -96,6 +96,7 @@ with entity series.
 """
 
 from datetime import datetime
+import json
 from pydantic import BaseModel, create_model
 from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
@@ -153,7 +154,7 @@ def json_val_to_attr(jval: Any) -> Optional[Attr]:
 
     Conversion is pretty basic:
       - `int` or `float` ==> `FloatAttr`
-      - `bool` ==> `FloatAttr`
+      - `bool` ==> `BoolAttr`
       - `str` ==> `TextAttr`
       - `list` ==> `ArrayAttr`
       - `dict` ==> `StructuredValueAttr`
@@ -162,7 +163,7 @@ def json_val_to_attr(jval: Any) -> Optional[Attr]:
     Notice JSON only has float but the Python parser converts numbers without
     a fractional part to `int` which is why we map `int` to `FloatAttr`. Also
     JSON null, which the parser converts to `None`, can't be mapped to any
-    attribute because there's no deterministic way to chose a corresponding
+    attribute because there's no deterministic way to choose a corresponding
     NGSI type for it.
 
     Args:
@@ -360,6 +361,24 @@ def from_raw_kv_to_dyn_entity(raw_entity: KVEntity) -> Entity:
 # that, if you access any of the attributes in the returned model instance,
 # e.g. x.attr1, you'll get the corresponding value from the original raw
 # entity dict.
+
+def to_ngsi_json(raw_entity_doc: str) -> str:
+    """Convert the input JSON document to NGSI-v2 JSON.
+
+    Notice this is just a convenience function to parse the JSON, call
+    `from_raw_kv_to_dyn_entity` on the parsed value and the convert the
+    generated NGSI entity to JSON.
+
+    Args:
+        raw_entity_doc: a JSON document containing an object which should
+            be key-value pair representation of an NGSI entity.
+
+    Returns:
+        NGSI-v2 JSON encoding the data in the input document.
+    """
+    raw_entity = json.loads(raw_entity_doc)
+    entity = from_raw_kv_to_dyn_entity(raw_entity)
+    return entity.to_json()
 
 
 class EntityUpdateNotification(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fipy"
-version = "0.6.1"
+version = "0.7.0"
 description = "Python utils for a little sweeter FIWARE experience."
 authors = ["c0c0n3"]
 

--- a/tests/unit/ngsi/test_entity.py
+++ b/tests/unit/ngsi/test_entity.py
@@ -18,6 +18,20 @@ def test_text_attr_from_value():
     assert t.value == 'howzit'
 
 
+def test_array_attr_from_value():
+    t = ArrayAttr.new([1, 2])
+
+    assert t.type == 'Array'
+    assert t.value == [1, 2]
+
+
+def test_struct_attr_from_value():
+    t = StructuredValueAttr.new({'x': 1})
+
+    assert t.type == 'StructuredValue'
+    assert t.value == {'x': 1}
+
+
 @pytest.mark.parametrize('raw', [True, False])
 def test_bool_attr_from_value(raw):
     t = BoolAttr.new(raw)

--- a/tests/unit/ngsi/test_entity_json.py
+++ b/tests/unit/ngsi/test_entity_json.py
@@ -1,0 +1,67 @@
+import json
+
+from fipy.ngsi.entity import *
+
+
+json_with_all_types = """
+{
+    "null_prop": null,
+    "bool_prop": true,
+    "int_prop": 1,
+    "float_prop": 1.0,
+    "string_prop": "yo",
+    "array_prop": [1, 2],
+    "object_prop": {"h": 3}
+}
+"""
+
+def test_json_null_to_attr():
+    parsed = json.loads(json_with_all_types)
+    attr = json_val_to_attr(parsed['null_prop'])
+
+    assert attr is None
+
+
+def test_json_to_bool_attr():
+    parsed = json.loads(json_with_all_types)
+    attr = json_val_to_attr(parsed['bool_prop'])
+
+    assert attr is not None
+    assert type(attr) == type(BoolAttr.new(False))
+    assert attr.value == True
+
+
+def test_json_to_float_attr():
+    parsed = json.loads(json_with_all_types)
+    for attr in (json_val_to_attr(parsed['int_prop']),
+                 json_val_to_attr(parsed['float_prop'])):
+        assert attr is not None
+        assert type(attr) == type(FloatAttr.new(0))
+        assert attr.value == 1
+
+
+def test_json_to_text_attr():
+    parsed = json.loads(json_with_all_types)
+    attr = json_val_to_attr(parsed['string_prop'])
+
+    assert attr is not None
+    assert type(attr) == type(TextAttr.new(""))
+    assert attr.value == "yo"
+
+
+def test_json_to_array_attr():
+    parsed = json.loads(json_with_all_types)
+    attr = json_val_to_attr(parsed['array_prop'])
+
+    assert attr is not None
+    assert type(attr) == type(ArrayAttr.new([]))
+    assert attr.value == [1, 2]
+
+
+def test_json_to_struct_attr():
+    parsed = json.loads(json_with_all_types)
+    attr = json_val_to_attr(parsed['object_prop'])
+
+    assert attr is not None
+    assert type(attr) == type(StructuredValueAttr.new({}))
+    assert attr.value == {"h": 3}

--- a/tests/unit/ngsi/test_entity_json.py
+++ b/tests/unit/ngsi/test_entity_json.py
@@ -104,3 +104,19 @@ def test_dyn_entity_from_kv_repr():
     assert entity.type == kv_entity['type']
     assert entity.position.value == '41.40338, 2.17403'
     assert entity.position.type == 'Text'
+
+def test_to_ngsi_json():
+    json_rep = """
+        {
+            "id": "urn:ngsi-ld:Drone:2",
+            "type": "Drone",
+            "position": "41.40338, 2.17403",
+            "speed": 12.3
+        }
+    """
+    ngsi_rep = to_ngsi_json(json_rep)
+
+    assert ngsi_rep == \
+        '{"id": "urn:ngsi-ld:Drone:2", "type": "Drone",' +\
+        ' "position": {"type": "Text", "value": "41.40338, 2.17403"},' +\
+        ' "speed": {"type": "Number", "value": 12.3}}'

--- a/tests/unit/ngsi/test_entity_json.py
+++ b/tests/unit/ngsi/test_entity_json.py
@@ -1,6 +1,7 @@
 import json
-
 from fipy.ngsi.entity import *
+
+from tests.util.fiware import BotEntity
 
 
 json_with_all_types = """
@@ -65,3 +66,41 @@ def test_json_to_struct_attr():
     assert attr is not None
     assert type(attr) == type(StructuredValueAttr.new({}))
     assert attr.value == {"h": 3}
+
+
+def test_entity_from_kv_repr():
+    json_rep = """
+        {
+            "id": "urn:ngsi-ld:Bot:1",
+            "type": "Bot",
+            "speed": 1.2
+        }
+    """
+    kv_entity = json.loads(json_rep)
+    entity = BotEntity.from_raw_kv(kv_entity)
+
+    assert entity is not None
+    assert type(entity) == BotEntity
+    assert entity.id == kv_entity['id']
+    assert entity.type == kv_entity['type']
+    assert entity.speed.value == 1.2
+    assert entity.speed.type == 'Number'
+
+
+def test_dyn_entity_from_kv_repr():
+    json_rep = """
+        {
+            "id": "urn:ngsi-ld:Drone:1",
+            "type": "Drone",
+            "position": "41.40338, 2.17403"
+        }
+    """
+    kv_entity = json.loads(json_rep)
+    entity = from_raw_kv_to_dyn_entity(kv_entity)
+
+    assert entity is not None
+    assert issubclass(type(entity), BaseEntity)
+    assert entity.id == kv_entity['id']
+    assert entity.type == kv_entity['type']
+    assert entity.position.value == '41.40338, 2.17403'
+    assert entity.position.type == 'Text'


### PR DESCRIPTION
This PR implements conversion of JSON objects to NGSI v2 entities.

### Usage

```python
>>> from fipy.ngsi.entity import *
``` 

Convert a JSON document containing an object to a JSON NGSI-v2 document:

```python
>>> json_doc = '{"id": "d4", "type": "Drone", "position": "41.40338, 2.17403"}'
>>> to_ngsi_json(json_doc)
'{"id": "d4", "type": "Drone", "position": {"type": "Text", "value": "41.40338, 2.17403"}}'
```

Same as above but gets a handle to the Pydantic model used under the bonnet to do the conversion.

```python
>>> raw_kv_drone_data = json.loads(json_doc)
>>> drone4 = from_raw_kv_to_dyn_entity(raw_kv_drone_data)
>>> drone4.to_json()
'{"id": "d4", "type": "Drone", "position": {"type": "Text", "value": "41.40338, 2.17403"}}'
``` 

Notice `from_raw_kv_to_dyn_entity` defines a new Pydantic model on the fly which subclasses `BaseEntity`, so `drone4` is  a `BaseEntity` and you can use it that way too.

```python
>>> type(drone4)  # Pydantic model dynamically created for us under the bonnet
<class 'pydantic.main.Drone'>
>>> issubclass(type(drone4), BaseEntity)
True
>>> drone4.position.value
'41.40338, 2.17403'
>>> print(drone4)
id='d4' type='Drone' position=TextAttr(type='Text', value='41.40338, 2.17403')
```

In general, it's best to define your own subclasses of `BaseEntity` to represent your NGSI entities so you can get Pydantic validation and other goodies for free. For example, here's the definition of a Bot entity

```python
>>> class BotEntity(BaseEntity):
...     type = 'Bot'
...     speed: Optional[FloatAttr]
```

and here's how to create a Bot instance from a dictionary.

```python
>>> raw_kv_bot_data = {
...     "id": "Bot:3", "type": "Bot", "speed": 12.3,
...     "other": "not in class def, ignore"
... }
>>> bot3 = BotEntity.from_raw_kv(raw_kv_bot_data)
>>> print(bot3)
id='Bot:3' type='Bot' speed=FloatAttr(type='Number', value=12.3)
```

Notice the "speed" dictionary key holds just a plain float value but that gets automatically converted to a `FloatAttr` for you. Also, the "other" key is ignored since there's no field named "other" in the `Bot` definition. (Sure, the `raw_kv_bot_data` could've been just as well the result of a call to `json.loads` :-)


### Conversion mechanics

The conversion is as follows. The input JSON object should have an `id` and a `type` field plus any other number of fields. Both the `id` and `type` fields should hold string values whereas the other fields can have any JSON value. E.g.

```json
{
    "id": "urn:ngsi-ld:Bot:3", 
    "type": "Bot",
    "speed": 12.3
}
```

The JSON object's `id` gets mapped to the NGSI entity's ID and likewise the `type` to the entity's type. Fields with `null` values are ignored whereas each remaining field f (besides `id` and `type`) gets mapped to an NGSI attribute having the same name and value as f. The JSON type of f's value determines the attribute type according to the conversion table below

```
 JSON       Python        NGSI
------      ------     -----------
number  ==> int    ==>  Number
            float  ==>  Number
string  ==> str    ==>  Text
boolean ==> bool   ==>  Boolean
array   ==> list   ==>  Array
object  ==> dict   ==>  StructuredValue
```

Notice JSON only has a float type but the Python parser converts numbers without a fractional part to `int` which is why we map `int` to NGSI Number. Also JSON null, which the parser converts to `None`, can't be mapped to any attribute because there's no deterministic way to choose a corresponding NGSI type for it---that's why we ignore JSON fields with null values.

Converting the example JSON object from earlier yields this (abstract representation of) NGSI entity:

```
entity
   id   = urn:ngsi-ld:Bot:3
   type = Bot
   speed
        type  = Number
        value = 12.3
``` 


### Pydantic models

The implementation works by mapping a parsed JSON object (i.e. a Python `dict`) to a Pydantic model. This can happen in two slightly different ways depending on whether you want to map the JSON data to an existing subclass of `BaseEntity` or you'd rather have a `BaseEntity` subclass generated for you on the fly---Pydantic dynamic model.

In the first case, JSON to existing `BaseEntity` subclass, the JSON to Python conversion happens as explained earlier except the conversion process ignores any JSON field whose name isn't in the list of attribute fields declared in the target `BaseEntity` subclass. For example, if you defined a Bot entity like

```python
class BotEntity(BaseEntity):
     type = 'Bot'
     speed: Optional[FloatAttr]
```

and you tried instantiating it from this JSON

```json
{
    "id": "urn:ngsi-ld:Bot:3", 
    "type": "Bot",
    "speed": 12.3,
    "other": "not in class def, ignore"
}
```

you'd see that the Bot's instance `id`, `type` and `speed` all get populated from the JSON whereas the `other` field in the JSON document gets ignored.

On the other hand, if you go down the on-the-fly-model-generation route, the implementation will create a new subclass of `BaseEntity` on the fly and add all the JSON fields to it, using the conversion mappings detailed earlier.
