### PR TITLE
Orion client enhancements

### DIFF
--- a/fipy/ngsi/orion.py
+++ b/fipy/ngsi/orion.py
@@ -2,7 +2,7 @@
 Wrapper calls to Orion Context Broker.
 """
 
-from typing import List
+from typing import List, Optional
 from uri import URI
 
 from fipy.http.jclient import JsonClient
@@ -66,6 +66,13 @@ class OrionClient:
         entity_arr = self._http.get(url=url, headers=self._ctx.headers())
         models = [like.from_raw(entity_dict) for entity_dict in entity_arr]
         return models
+
+    def fetch_entity(self, like: Entity) -> Optional[Entity]:
+        query = {'id': like.id, 'type': like.type}
+        url = self._urls.entities(query)
+        entity_arr = self._http.get(url=url, headers=self._ctx.headers())
+        models = [like.from_raw(entity_dict) for entity_dict in entity_arr]
+        return models[0] if len(models) > 0 else None
 
     def subscribe(self, sub: dict):
         url = self._urls.subscriptions()

--- a/fipy/ngsi/orion.py
+++ b/fipy/ngsi/orion.py
@@ -35,24 +35,54 @@ class OrionEndpoints:
 
 
 class OrionClient:
+    """Client to interact with Orion.
+    """
 
     def __init__(self, base_url: URI, ctx: FiwareContext):
+        """Create a new client.
+
+        Args:
+            base_url: Orion's root URL, e.g. URI('http://localhost:1026').
+            ctx: the FIWARE context to use. Notice the service determines
+                which Orion tenant DB this client will interact with.
+        """
         self._urls = OrionEndpoints(base_url)
         self._ctx = ctx
         self._http = JsonClient()
 
     def upsert_entity(self, data: BaseEntity):
+        """Put the given entity data in Orion's context.
+        If there's no entity, then insert a new one. Otherwise update the
+        existing one.
+
+        Args:
+            data: entity data to put in the context.
+        """
         url = self._urls.entities({'options': 'upsert'})
         self._http.post(url=url, json_payload=data.dict(),
                         headers=self._ctx.headers())
 
+
     def upsert_entities(self, data: List[BaseEntity]):
+        """Same as upsert_entity but for a list of entities.
+
+        Args:
+            data: entities to put in the context.
+        """
         url = self._urls.update_op()
         payload = EntitiesUpsert(entities=data)
         self._http.post(url=url, json_payload=payload.dict(),
                         headers=self._ctx.headers())
 
     def list_entities(self) -> List[BaseEntity]:
+        """Fetch an entity summary of each entity in the context.
+
+        Returns:
+            A list of `BaseEntity`, one for each entity found in the
+            context. Notice these are partial representations of the
+            entities, they only have the `id` and `type` fields and
+            no attributes.
+        """
         url = self._urls.entities({'attrs': 'id'})  # (*)
         entity_arr = self._http.get(url=url, headers=self._ctx.headers())
         models = [BaseEntity.parse_obj(entity_dict)
@@ -62,12 +92,34 @@ class OrionClient:
     # See: https://github.com/c0c0n3/kitt4sme.fipy/issues/12
 
     def list_entities_of_type(self, like: Entity) -> List[Entity]:
+        """Fetch all entities of the given type.
+
+        Args:
+            like: example entity to specify the type of the entities
+                to fetch.
+
+        Returns:
+            A list of entities of the requested type. Each entity holds the
+            full representation with all the attributes plus the `id` and
+            `type` fields.
+        """
         url = self._urls.entities({'type': like.type})
         entity_arr = self._http.get(url=url, headers=self._ctx.headers())
         models = [like.from_raw(entity_dict) for entity_dict in entity_arr]
         return models
 
     def fetch_entity(self, like: Entity) -> Optional[Entity]:
+        """Fetch the entity of the given type and ID.
+
+        Args:
+            like: example entity to specify the type and ID of the entity
+                to fetch.
+
+        Returns:
+            The requested entity if it exists, `None` otherwise. The entity
+            holds the full representation with all the attributes plus the
+            `id` and `type` fields.
+        """
         query = {'id': like.id, 'type': like.type}
         url = self._urls.entities(query)
         entity_arr = self._http.get(url=url, headers=self._ctx.headers())
@@ -75,10 +127,20 @@ class OrionClient:
         return models[0] if len(models) > 0 else None
 
     def subscribe(self, sub: dict):
+        """Create a new subscription.
+
+        Args:
+            sub: subscription data.
+        """
         url = self._urls.subscriptions()
         self._http.post(url=url, json_payload=sub,
                         headers=self._ctx.headers())
 
     def list_subscriptions(self) -> List[dict]:
+        """Fetch all the current subscriptions.
+
+        Returns:
+            A list of `dict`, each holding the data of a subscription.
+        """
         url = self._urls.subscriptions()
         return self._http.get(url=url, headers=self._ctx.headers())

--- a/fipy/ngsi/orion.py
+++ b/fipy/ngsi/orion.py
@@ -2,11 +2,11 @@
 Wrapper calls to Orion Context Broker.
 """
 
-from typing import List, Type
+from typing import List
 from uri import URI
 
 from fipy.http.jclient import JsonClient
-from fipy.ngsi.entity import BaseEntity, EntitiesUpsert
+from fipy.ngsi.entity import BaseEntity, Entity, EntitiesUpsert
 from fipy.ngsi.headers import FiwareContext
 
 
@@ -59,11 +59,10 @@ class OrionClient:
                   for entity_dict in entity_arr]
         return models
 
-    def list_entities_of_type(self, like: Type[BaseEntity]) \
-            -> List[BaseEntity]:
+    def list_entities_of_type(self, like: Entity) -> List[Entity]:
         url = self._urls.entities({'type': like.type})
         entity_arr = self._http.get(url=url, headers=self._ctx.headers())
-        models = [like.parse_obj(entity_dict) for entity_dict in entity_arr]
+        models = [like.from_raw(entity_dict) for entity_dict in entity_arr]
         return models
 
     def subscribe(self, sub: dict):

--- a/fipy/ngsi/orion.py
+++ b/fipy/ngsi/orion.py
@@ -53,11 +53,13 @@ class OrionClient:
                         headers=self._ctx.headers())
 
     def list_entities(self) -> List[BaseEntity]:
-        url = self._urls.entities()
+        url = self._urls.entities({'attrs': 'id'})  # (*)
         entity_arr = self._http.get(url=url, headers=self._ctx.headers())
         models = [BaseEntity.parse_obj(entity_dict)
                   for entity_dict in entity_arr]
         return models
+    # NOTE. Include only `id` and `type` fields of each entity.
+    # See: https://github.com/c0c0n3/kitt4sme.fipy/issues/12
 
     def list_entities_of_type(self, like: Entity) -> List[Entity]:
         url = self._urls.entities({'type': like.type})

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - mongodb
 
   timescale:
-    image: timescale/timescaledb-postgis:1.7.5-pg12
+    image: timescale/timescaledb-postgis:2.3.0-pg13
     ports:
       - "5432:5432"
     networks:
@@ -27,7 +27,7 @@ services:
       - POSTGRES_PASSWORD=*
 
   quantumleap-db-setup:
-    image: orchestracities/quantumleap-pg-init
+    image: orchestracities/quantumleap-pg-init:0.8.3
     depends_on:
       - timescale
     networks:
@@ -39,7 +39,7 @@ services:
       - PG_PASS=*
 
   quantumleap:
-    image: orchestracities/quantumleap
+    image: orchestracities/quantumleap:0.8.3
     depends_on:
       - timescale
     networks:

--- a/tests/e2e/test_current_ctx.py
+++ b/tests/e2e/test_current_ctx.py
@@ -39,3 +39,6 @@ def test_bots(orion: OrionClient):
         assert want.id == got.id
         assert abs(want.speed.value - got.speed.value) < 0.01
         assert want.direction.value == want.direction.value
+
+    summaries = orion.list_entities()
+    assert len(summaries) == 2

--- a/tests/e2e/test_current_ctx.py
+++ b/tests/e2e/test_current_ctx.py
@@ -25,6 +25,12 @@ def has_bot_entities(orion: OrionClient) -> bool:
     return len(es) > 0
 
 
+def assert_bot_entity(want: BotEntity, got: BotEntity):
+    assert want.id == got.id
+    assert abs(want.speed.value - got.speed.value) < 0.01
+    assert want.direction.value == want.direction.value
+
+
 def test_bots(orion: OrionClient):
     sorted_bots = upload_bot_entities(orion)
 
@@ -34,11 +40,9 @@ def test_bots(orion: OrionClient):
 
     assert len(sorted_bots) == len(sorted_orion_bots)
     for i in range(len(sorted_bots)):
-        want = sorted_bots[i]
-        got = sorted_orion_bots[i]
-        assert want.id == got.id
-        assert abs(want.speed.value - got.speed.value) < 0.01
-        assert want.direction.value == want.direction.value
+        assert_bot_entity(want=sorted_bots[i], got=sorted_orion_bots[i])
+        orion_bot = orion.fetch_entity(sorted_bots[i])
+        assert_bot_entity(want=sorted_bots[i], got=orion_bot)
 
     summaries = orion.list_entities()
     assert len(summaries) == 2

--- a/tests/e2e/test_current_ctx.py
+++ b/tests/e2e/test_current_ctx.py
@@ -34,4 +34,8 @@ def test_bots(orion: OrionClient):
 
     assert len(sorted_bots) == len(sorted_orion_bots)
     for i in range(len(sorted_bots)):
-        assert sorted_bots[i].id == sorted_orion_bots[i].id
+        want = sorted_bots[i]
+        got = sorted_orion_bots[i]
+        assert want.id == got.id
+        assert abs(want.speed.value - got.speed.value) < 0.01
+        assert want.direction.value == want.direction.value


### PR DESCRIPTION
This PR implements some new functionality for the Orion client and fixes some issues. Specifically:

* Performance. The client now doesn't download full entities anymore to build entity summaries. Fixes #12.
* Single entity retrieval. The client now has an additional method to fetch a single entity. This is a common use-case, so we should have a method for it. In the past, you could've done it w/ a combination of existing methods, but from a usability standpoint a dedicated method is better.
* Typed entity instantiation. Entity instantiation now uses the `from_raw` method which checks the NGSI type is the same as that declared in the Python class used to represent the NGSI entity.
* Docker images for the end-to-end tests. Pinned down to the versions we're currently using in kitt4sme.live. 
* Docs. Basic documentation added to all client methods.