### PR TITLE
Fix URI dependency

### DIFF
--- a/fipy/__init__.py
+++ b/fipy/__init__.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Optional, Tuple
 
-__version__ = '0.10.0'
+__version__ = '0.11.0'
 
 
 def pyproject_file() -> Path:

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,19 +8,18 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "22.2.0"
+version = "23.1.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
-cov = ["attrs", "coverage-enable-subprocess", "coverage[toml] (>=5.3)"]
-dev = ["attrs"]
-docs = ["furo", "sphinx", "myst-parser", "zope.interface", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier"]
-tests = ["attrs", "zope.interface"]
-tests-no-zope = ["hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist", "cloudpickle", "mypy (>=0.971,<0.990)", "pytest-mypy-plugins"]
-tests_no_zope = ["hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist", "cloudpickle", "mypy (>=0.971,<0.990)", "pytest-mypy-plugins"]
+cov = ["attrs", "coverage[toml] (>=5.3)"]
+dev = ["attrs", "pre-commit"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
+tests = ["attrs", "zope-interface"]
+tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest-mypy-plugins", "pytest-xdist", "pytest (>=4.3.0)"]
 
 [[package]]
 name = "bitmath"
@@ -258,7 +257,7 @@ http = ["requests"]
 [package.source]
 type = "git"
 url = "https://github.com/marrow/uri.git"
-reference = "5b58db8"
+reference = "5b58db87451ca4680004a8993a56bfc4dafff4d4"
 resolved_reference = "5b58db87451ca4680004a8993a56bfc4dafff4d4"
 
 [[package]]
@@ -277,7 +276,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "ff34f91dcc9235823c06e74e10e1165fcb753b04735bba6d1743466e371053f4"
+content-hash = "8127b3f686df0293b0e00b6cba0b302f8a4c0caf240a86fd1523f581c12e6a7a"
 
 [metadata.files]
 atomicwrites = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fipy"
-version = "0.10.0"
+version = "0.11.0"
 description = "Python utils for a little sweeter FIWARE experience."
 authors = ["c0c0n3"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["c0c0n3"]
 [tool.poetry.dependencies]
 python = "^3.8"
 pydantic = "^1.9.0"
-uri = { git = "https://github.com/marrow/uri.git", rev = "5b58db8" }
+uri = { git = "https://github.com/marrow/uri.git", rev = "5b58db87451ca4680004a8993a56bfc4dafff4d4" }
 requests = "^2.27.1"
 PyYAML = "^6.0"
 bitmath = "^1.3.3"


### PR DESCRIPTION
This PR fixes the URI dependency in Poetry 1.2 by specifying a full commit hash. See #17 for the details.